### PR TITLE
Android端末で文字色がピンクになるバグを修正

### DIFF
--- a/AirTote/App.xaml.cs
+++ b/AirTote/App.xaml.cs
@@ -2,6 +2,11 @@ namespace AirTote;
 
 public partial class App : Application
 {
+	static public Color LightSecondaryColor
+		=> Current?.Resources[nameof(LightSecondaryColor)] as Color ?? Colors.Black;
+	static public Color DarkSecondaryColor
+		=> Current?.Resources[nameof(DarkSecondaryColor)] as Color ?? Colors.White;
+
 	public App()
 	{
 		InitializeComponent();

--- a/AirTote/Components/MyTableView.cs
+++ b/AirTote/Components/MyTableView.cs
@@ -28,7 +28,6 @@ public class TableView : Microsoft.Maui.Controls.TableView
 
 	static void SetTextColors(System.Collections.IEnumerable? e)
 	{
-		Console.WriteLine("\t" + nameof(SetTextColors));
 		if (e is null)
 			return;
 

--- a/AirTote/Components/MyTableView.cs
+++ b/AirTote/Components/MyTableView.cs
@@ -41,6 +41,7 @@ public class TableView : Microsoft.Maui.Controls.TableView
 					SetTextColors(s);
 					break;
 
+				// TextCell and ImageCell(=inherited from TextCell)
 				case TextCell c:
 					c.SetAppThemeColor(
 						TextCell.TextColorProperty,
@@ -52,6 +53,10 @@ public class TableView : Microsoft.Maui.Controls.TableView
 						App.LightSecondaryColor.WithAlpha(Alpha),
 						App.DarkSecondaryColor.WithAlpha(Alpha)
 					);
+					break;
+
+				// no textcolor props
+				case SwitchCell c:
 					break;
 
 				case EntryCell c:

--- a/AirTote/Components/MyTableView.cs
+++ b/AirTote/Components/MyTableView.cs
@@ -1,0 +1,68 @@
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace AirTote.Components;
+
+public class TableView : Microsoft.Maui.Controls.TableView
+{
+	const float Alpha = 0.8f;
+
+	public TableView()
+	{
+		Root.CollectionChanged += Root_CollectionChanged;
+		SetTextColors(Root);
+	}
+
+	protected override void OnModelChanged()
+	{
+		base.OnModelChanged();
+		Root.CollectionChanged += Root_CollectionChanged;
+		SetTextColors(Root);
+	}
+
+	private static void Root_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+		=> SetTextColors(e.NewItems);
+	private static void TableSection_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+		=> SetTextColors(e.NewItems);
+
+	static void SetTextColors(System.Collections.IEnumerable? e)
+	{
+		Console.WriteLine("\t" + nameof(SetTextColors));
+		if (e is null)
+			return;
+
+		foreach (var v in e)
+		{
+			switch (v)
+			{
+				case TableSection s:
+					s.SetAppThemeColor(TableSectionBase.TextColorProperty, App.LightSecondaryColor, App.DarkSecondaryColor);
+					s.CollectionChanged += TableSection_CollectionChanged;
+					SetTextColors(s);
+					break;
+
+				case TextCell c:
+					c.SetAppThemeColor(
+						TextCell.TextColorProperty,
+						App.LightSecondaryColor,
+						App.DarkSecondaryColor
+					);
+					c.SetAppThemeColor(
+						TextCell.DetailColorProperty,
+						App.LightSecondaryColor.WithAlpha(Alpha),
+						App.DarkSecondaryColor.WithAlpha(Alpha)
+					);
+					break;
+
+				case EntryCell c:
+					c.SetAppThemeColor(
+						EntryCell.LabelColorProperty,
+						App.LightSecondaryColor,
+						App.DarkSecondaryColor
+					);
+					break;
+			}
+		}
+	}
+}

--- a/AirTote/Pages/SettingPage.xaml
+++ b/AirTote/Pages/SettingPage.xaml
@@ -5,6 +5,7 @@
 	xmlns:ViewModels="clr-namespace:AirTote.ViewModels"
 	xmlns:tpv="clr-namespace:AirTote.TwoPaneView;assembly=AirTote.TwoPaneView.MAUI"
 	xmlns:p="clr-namespace:AirTote.Pages.Settings"
+	xmlns:c="clr-namespace:AirTote.Components"
 	x:DataType="ViewModels:SettingPageViewModel"
 	Title="{Binding Title}"
 	x:Class="AirTote.Pages.SettingPage">
@@ -13,7 +14,7 @@
 		LeftPaneWidth="300"
 		RightPaneWidth="*"
 		MinimumTwoPaneWidth="500">
-		<TableView
+		<c:TableView
 			Intent="Settings">
 			<TableRoot>
 				<TableSection
@@ -26,6 +27,6 @@
 
 			</TableRoot>
 
-		</TableView>
+		</c:TableView>
 	</tpv:TwoPaneView>
 </ContentPage>

--- a/AirTote/Pages/Settings/AISJapan.xaml
+++ b/AirTote/Pages/Settings/AISJapan.xaml
@@ -2,6 +2,7 @@
 <ContentPage
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:c="clr-namespace:AirTote.Components"
 	xmlns:ViewModels="clr-namespace:AirTote.ViewModels.SettingPages"
 	x:DataType="ViewModels:AISJapanViewModel"
 	x:Class="AirTote.Pages.Settings.AISJapan"
@@ -9,7 +10,7 @@
 	<ContentPage.Resources>
 		<Thickness x:Key="CellMargin">4</Thickness>
 	</ContentPage.Resources>
-	<TableView
+	<c:TableView
 		HasUnevenRows="True"
 		Intent="Data">
 		<TableRoot>
@@ -117,5 +118,5 @@
 				</ViewCell>
 			</TableSection>
 		</TableRoot>
-	</TableView>
+	</c:TableView>
 </ContentPage>


### PR DESCRIPTION
resolves #101

カスタムの文字色を適用することができない点は、面倒なので仕様とする。

![Screenshot_1661443486](https://user-images.githubusercontent.com/31824852/186715864-4a0b3040-7830-4b66-860e-251607b4aa40.png)
 