### PR TITLE
ライセンスIDに半角スペースが含まれていた場合にうまく処理できないバグを修正

### DIFF
--- a/tools/getThirdPartyLicenseJson.py
+++ b/tools/getThirdPartyLicenseJson.py
@@ -142,7 +142,7 @@ async def dumpLicenseTextFileFromLicenseUrl(session: ClientSession, targetDir: s
 
 
 async def dumpLicenseTextFileFromLicenseExpression(session: ClientSession, licenseInfo: LicenseInfo, targetDir: str):
-  licenseList = [str(v) for v in re.split("\(|\)|OR|AND", licenseInfo.license) if v != '' or v.isspace()]
+  licenseList = [str(v) for v in re.split("\(|\)| ", licenseInfo.license) if (v != '' or v.isspace()) and v != "OR" and v != "AND"]
   for licenseId in licenseList:
     licenseFilePath = joinPath(targetDir, licenseId)
     if exists(licenseFilePath):


### PR DESCRIPTION
例えば`MS-PL OR Apache-2.0`などの場合、`MS-PL `と` Apache-2.0`に分割されてしまい、エラーが出ていた。

今回の変更で、正常に`MS-PL`と`Apache-2.0`が出力されるようになる。