### PR TITLE
AISJapanへのログインに再起動が必要になる場合がある問題を修正

### DIFF
--- a/AirTote/Pages/aero.xaml.cs
+++ b/AirTote/Pages/aero.xaml.cs
@@ -15,19 +15,23 @@ namespace AirTote.Pages
 			InitializeComponent();
 			BindingContext = html;
 
-			Task.Run(async () =>
+			Appearing += Aero_Appearing;
+		}
+
+		private async void Aero_Appearing(object? sender, EventArgs e)
+		{
+			html.HTML = null;
+
+			try
 			{
-				try
-				{
-					ais = await AISJapan.FromSecureStorageAsync(SecureStorage.Default);
-				}
-				catch (Exception ex)
-				{
-					MainThread.BeginInvokeOnMainThread(async () =>
-						await Shell.Current.CurrentPage.DisplayAlert("AIS Japan Account Error", "設定画面にて自身のアカウントを設定してください。\n" + ex.Message, "OK")
-					);
-				}
-			});
+				ais = await AISJapan.FromSecureStorageIfNeededAsync(SecureStorage.Default, ais);
+			}
+			catch (Exception ex)
+			{
+				ais = null;
+
+				MsgBox.DisplayAlert("AIS Japan Account Error", "設定画面にて自身のアカウントを設定してください。\n" + ex.Message, "OK");
+			}
 		}
 
 		private void SUPsView_Clicked(object sender, EventArgs e)

--- a/AirTote/Pages/aero.xaml.cs
+++ b/AirTote/Pages/aero.xaml.cs
@@ -30,39 +30,22 @@ namespace AirTote.Pages
 			});
 		}
 
-		private async void SUPsView_Clicked(object sender, EventArgs e)
-		{
-			System.Diagnostics.Debug.WriteLine("PASS Running");
-			if (ais is null)
-				return;
-			var result = await ais.GetPage("https://aisjapan.mlit.go.jp/html/AIP/html/20220224/eSUP/JP-eSUPs-en-JP.html");
-			System.Diagnostics.Debug.WriteLine(result);
-			html.HTML = new HtmlWebViewSource()
-			{
-				Html = result
-			};
-		}
+		private void SUPsView_Clicked(object sender, EventArgs e)
+			=> ShowPageAsync("https://aisjapan.mlit.go.jp/html/AIP/html/20220224/eSUP/JP-eSUPs-en-JP.html");
 
-		private async void AIPView_Clicked(object sender, EventArgs e)
-		{
-			System.Diagnostics.Debug.WriteLine("PASS Running");
-			if (ais is null)
-				return;
-			var result = await ais.GetPage("https://aisjapan.mlit.go.jp/html/AIP/html/20220224/eAIP/20220301/JP-menu-en-JP.html");
-			System.Diagnostics.Debug.WriteLine(result);
-			html.HTML = new HtmlWebViewSource()
-			{
-				Html = result
-			};
-		}
+		private void AIPView_Clicked(object sender, EventArgs e)
+			=> ShowPageAsync("https://aisjapan.mlit.go.jp/html/AIP/html/20220224/eAIP/20220301/JP-menu-en-JP.html");
 
-		private async void AICsView_Clicked(object sender, EventArgs e)
+		private void AICsView_Clicked(object sender, EventArgs e)
+			=> ShowPageAsync("https://aisjapan.mlit.go.jp/html/AIP/html/20220324/eAIC/JP-eAICs-jp-JP.html");
+
+		async void ShowPageAsync(string url)
 		{
-			System.Diagnostics.Debug.WriteLine("PASS Running");
 			if (ais is null)
 				return;
-			var result = await ais.GetPage("https://aisjapan.mlit.go.jp/html/AIP/html/20220324/eAIC/JP-eAICs-jp-JP.html");
-			System.Diagnostics.Debug.WriteLine(result);
+
+			var result = await ais.GetPage(url);
+
 			html.HTML = new HtmlWebViewSource()
 			{
 				Html = result

--- a/AirTote/Services/MsgBox.cs
+++ b/AirTote/Services/MsgBox.cs
@@ -2,15 +2,17 @@ namespace AirTote.Services;
 
 static public class MsgBox
 {
+	static private Page Host => Shell.Current.CurrentPage ?? Shell.Current;
+
 	static public void DisplayAlert(string title, string msg, string cancelBtnText)
 		=> MainThread.BeginInvokeOnMainThread(() =>
-			Shell.Current.CurrentPage.DisplayAlert(title, msg, cancelBtnText)
+			Host.DisplayAlert(title, msg, cancelBtnText)
 		);
 
 	static public void DisplayAlert(string title, string msg, string acceptBtnText, string cancelBtnText, Action<bool> action, bool actionOnMainThread = false)
 		=> MainThread.BeginInvokeOnMainThread(async () =>
 			{
-				var result = await Shell.Current.CurrentPage.DisplayAlert(title, msg, acceptBtnText, cancelBtnText);
+				var result = await Host.DisplayAlert(title, msg, acceptBtnText, cancelBtnText);
 
 				if (action is null)
 					return;
@@ -24,12 +26,12 @@ static public class MsgBox
 
 	static public Task DisplayAlertAsync(string title, string msg, string cancelBtnText)
 		=> MainThread.InvokeOnMainThreadAsync(() =>
-			Shell.Current.CurrentPage.DisplayAlert(title, msg, cancelBtnText)
+			Host.DisplayAlert(title, msg, cancelBtnText)
 		);
 
 	static public Task<bool> DisplayAlertAsync(string title, string msg, string acceptBtnText, string cancelBtnText)
 		=> MainThread.InvokeOnMainThreadAsync(() =>
-			Shell.Current.CurrentPage.DisplayAlert(title, msg, acceptBtnText, cancelBtnText)
+			Host.DisplayAlert(title, msg, acceptBtnText, cancelBtnText)
 		);
 }
 


### PR DESCRIPTION
resolves #97

コンストラクタでサインインを実行するようにしていたが、それだとページ初期化時にしかサインインが実行されない。

AIS Japanのアカウント設定機能を実装したことにより、ページの表示ごとに異なる資格情報を使用する必要がある可能性がある。

そこで、Appearingイベントが発火した際に資格情報の再チェックを行うようにした。