### PR TITLE
ナウキャストについて表示する時間を調整可能にした

### DIFF
--- a/AirTote.Services.JMA/AirTote.Services.JMA.csproj
+++ b/AirTote.Services.JMA/AirTote.Services.JMA.csproj
@@ -5,6 +5,9 @@
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 	<ItemGroup>
+		<PackageReference Include="Mapsui" Version="4.0.0-beta.5" />
+	</ItemGroup>
+	<ItemGroup>
 		<ProjectReference Include="..\AirTote.Services\AirTote.Services.csproj" />
 	</ItemGroup>
 </Project>

--- a/AirTote.Services.JMA/AirTote.Services.JMA.csproj
+++ b/AirTote.Services.JMA/AirTote.Services.JMA.csproj
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\AirTote.Services\AirTote.Services.csproj" />
+	</ItemGroup>
+</Project>

--- a/AirTote.Services.JMA/JMATilesProvider.cs
+++ b/AirTote.Services.JMA/JMATilesProvider.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using AirTote.Services.JMA.Models;
+
+using BruTile.Predefined;
+using BruTile.Web;
+
+using Mapsui.Tiling.Layers;
+
+namespace AirTote.Services.JMA;
+
+public enum NowC_Types
+{
+	HRPNs,
+	THNs,
+	TRNs,
+	LIDEN,
+}
+
+public class JMATilesProvider
+{
+	// hrpns valid history list: https://www.jma.go.jp/bosai/jmatile/data/nowc/targetTimes_N1.json
+	// hrpns forecast list: https://www.jma.go.jp/bosai/jmatile/data/nowc/targetTimes_N2.json
+	// others list: https://www.jma.go.jp/bosai/jmatile/data/nowc/targetTimes_N3.json
+
+	public TargetTimes? HRPNs_Latest { get; }
+
+	public IReadOnlyList<TargetTimes> HRPNsTimeList { get; }
+	public IReadOnlyList<TargetTimes> THNsTimeList { get; }
+	public IReadOnlyList<TargetTimes> TRNsTimeList { get; }
+	public IReadOnlyList<TargetTimes> LIDENTimeList { get; }
+
+	private JMATilesProvider(
+		TargetTimes? hrpns_latest,
+		IReadOnlyList<TargetTimes> hrpns,
+		IReadOnlyList<TargetTimes> thns,
+		IReadOnlyList<TargetTimes> trns,
+		IReadOnlyList<TargetTimes> liden)
+	{
+		HRPNs_Latest = hrpns_latest;
+
+		HRPNsTimeList = hrpns;
+		THNsTimeList = thns;
+		TRNsTimeList = trns;
+		LIDENTimeList = liden;
+	}
+
+	public static async Task<JMATilesProvider> Init()
+	{
+		TargetTimes? latest = null;
+		List<TargetTimes> hrpns = new();
+		List<TargetTimes> thns = new();
+		List<TargetTimes> trns = new();
+		List<TargetTimes> liden = new();
+
+		// HRPNs history
+		using (var stream = await HttpService.HttpClient.GetStreamAsync("https://www.jma.go.jp/bosai/jmatile/data/nowc/targetTimes_N1.json"))
+		{
+			var result = await JsonSerializer.DeserializeAsync<TargetTimes[]>(stream);
+
+			if (result is not null)
+			{
+				hrpns = result
+					.Where(v => v.elements.Contains(TargetTimes.TYPE_HIGH_RESOLUTION_PRECIPITATION_NOWCASTS))
+					.ToList();
+
+				latest = hrpns.MaxBy(v => v.validtime);
+			}
+		}
+
+		using (var stream = await HttpService.HttpClient.GetStreamAsync("https://www.jma.go.jp/bosai/jmatile/data/nowc/targetTimes_N2.json"))
+		{
+			var result = await JsonSerializer.DeserializeAsync<TargetTimes[]>(stream);
+
+			if (result is not null)
+			{
+				hrpns.AddRange(result.Where(v => v.elements.Contains(TargetTimes.TYPE_HIGH_RESOLUTION_PRECIPITATION_NOWCASTS)));
+			}
+		}
+
+		hrpns.Sort((a, b) => DateTime.Compare(a.validtime, b.validtime));
+
+		using (var stream = await HttpService.HttpClient.GetStreamAsync("https://www.jma.go.jp/bosai/jmatile/data/nowc/targetTimes_N3.json"))
+		{
+			var result = await JsonSerializer.DeserializeAsync<TargetTimes[]>(stream);
+
+			if (result is not null)
+			{
+				thns = result.Where(v => v.elements.Contains(TargetTimes.TYPE_THUNDER_NOWCASTS)).ToList();
+				trns = result.Where(v => v.elements.Contains(TargetTimes.TYPE_TORNADO_NOWCASTS)).ToList();
+				liden = result.Where(v => v.elements.Contains(TargetTimes.TYPE_LIGHTNING_DETECTION_NETWORK_SYSTEM)).ToList();
+			}
+		}
+
+		return new(latest, hrpns, thns, trns, liden);
+	}
+
+	public TileLayer GetLayer(TargetTimes targetTime, NowC_Types type)
+	{
+		string type_name = type switch
+		{
+			NowC_Types.HRPNs => "hrpns",
+			NowC_Types.THNs => "thns",
+			NowC_Types.TRNs => "trns",
+			_ => throw new ArgumentException($"The type `{type}` is not supported", nameof(type))
+		};
+
+		string name = type switch
+		{
+			NowC_Types.HRPNs => "雨雲の動き",
+			NowC_Types.THNs => "雷活動度",
+			NowC_Types.TRNs => "竜巻発生確度",
+			_ => "不明なデータ"
+		};
+
+		TileLayer layer = new(new HttpTileSource(
+				new GlobalSphericalMercator(4, 10),
+				@$"https://www.jma.go.jp/bosai/jmatile/data/nowc/{targetTime.basetime:yyyyMMddhhmmss}/none/{targetTime.validtime:yyyyMMddhhmmss}/surf/{type_name}/" + "{z}/{x}/{y}.png",
+				name: name,
+				tileFetcher: HttpService.GetByteArrayAsync,
+				userAgent: HttpService.USER_AGENT,
+				attribution: new("出典: 気象庁 ナウキャスト", "https://www.jma.go.jp/bosai/nowc/")
+			))
+		{
+			Name = name,
+		};
+
+		layer.Attribution.Enabled = false;
+		layer.IsMapInfoLayer = false;
+
+		return layer;
+	}
+}

--- a/AirTote.Services.JMA/JMATilesProvider.cs
+++ b/AirTote.Services.JMA/JMATilesProvider.cs
@@ -98,8 +98,8 @@ public class JMATilesProvider
 			hrpns.AddRange(targetTimes_N2.Where(v => v.elements.Contains(TargetTimes.TYPE_HIGH_RESOLUTION_PRECIPITATION_NOWCASTS)));
 		}
 
-
-		hrpns.Sort((a, b) => string.Compare(a.validtime, b.validtime));
+		// [0]が最新(Max)、[Last]が過去(Min)にする
+		hrpns.Sort((a, b) => string.Compare(b.validtime, a.validtime));
 
 		TargetTimes[] targetTimes_N3 = await GetTargetTimes("targetTimes_N3.json");
 

--- a/AirTote.Services.JMA/JMATilesProvider.cs
+++ b/AirTote.Services.JMA/JMATilesProvider.cs
@@ -113,7 +113,7 @@ public class JMATilesProvider
 		return new(latest, hrpns, thns, trns, liden);
 	}
 
-	public TileLayer GetLayer(TargetTimes targetTime, NowC_Types type)
+	public static TileLayer GetLayer(TargetTimes targetTime, NowC_Types type)
 	{
 		string type_name = type switch
 		{

--- a/AirTote.Services.JMA/Models/TargetTimes.cs
+++ b/AirTote.Services.JMA/Models/TargetTimes.cs
@@ -1,0 +1,17 @@
+using System;
+namespace AirTote.Services.JMA.Models;
+
+public record TargetTimes(
+	DateTime basetime,
+	DateTime validtime,
+	string[] elements
+)
+{
+	public const string TYPE_HIGH_RESOLUTION_PRECIPITATION_NOWCASTS = "hrpns";
+	public const string TYPE_HIGH_RESOLUTION_PRECIPITATION_NOWCASTS_NO_DATA = "hrpns_nd";
+	public const string TYPE_THUNDER_NOWCASTS = "thns";
+	public const string TYPE_THUNDER_NOWCASTS_NO_DATA = "thns_nd";
+	public const string TYPE_TORNADO_NOWCASTS = "trns";
+	public const string TYPE_TORNADO_NOWCASTS_NO_DATA = "trns_nd";
+	public const string TYPE_LIGHTNING_DETECTION_NETWORK_SYSTEM = "liden";
+}

--- a/AirTote.Services.JMA/Models/TargetTimes.cs
+++ b/AirTote.Services.JMA/Models/TargetTimes.cs
@@ -1,9 +1,8 @@
-using System;
 namespace AirTote.Services.JMA.Models;
 
 public record TargetTimes(
-	DateTime basetime,
-	DateTime validtime,
+	string basetime,
+	string validtime,
 	string[] elements
 )
 {

--- a/AirTote.Services/HttpService.cs
+++ b/AirTote.Services/HttpService.cs
@@ -23,6 +23,8 @@ public class HttpService
 			));
 	}
 
+	static public string USER_AGENT => HttpService.HttpClient.DefaultRequestHeaders.UserAgent.ToString();
+
 	static public async Task<byte[]> GetByteArrayAsync(Uri uri)
 	{
 		try

--- a/AirTote.Services/HttpService.cs
+++ b/AirTote.Services/HttpService.cs
@@ -1,6 +1,8 @@
+using System;
 using System.IO;
 using System.Net.Http;
 using System.Reflection;
+using System.Threading.Tasks;
 
 namespace AirTote.Services;
 
@@ -19,6 +21,21 @@ public class HttpService
 			Path.GetFileNameWithoutExtension(System.AppDomain.CurrentDomain.FriendlyName),
 			Assembly.GetEntryAssembly()?.GetName().Version?.ToString() ?? "1.0"
 			));
+	}
+
+	static public async Task<byte[]> GetByteArrayAsync(Uri uri)
+	{
+		try
+		{
+			using HttpResponseMessage res = await HttpService.HttpClient.GetAsync(uri);
+
+			return res.IsSuccessStatusCode ? await res.Content.ReadAsByteArrayAsync() : Array.Empty<byte>();
+		}
+		catch (TaskCanceledException)
+		{
+			// When Timeout
+			return Array.Empty<byte>();
+		}
 	}
 }
 

--- a/AirTote.SketchPad.MAUI/AirTote.SketchPad.MAUI.csproj
+++ b/AirTote.SketchPad.MAUI/AirTote.SketchPad.MAUI.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0-ios;net6.0-android</TargetFrameworks>
+		<TargetFrameworks>net6.0-ios13.0;net6.0-android</TargetFrameworks>
 		<RootNamespace>AirTote.SketchPad</RootNamespace>
 		<LangVersion>preview</LangVersion>
 		<Nullable>enable</Nullable>

--- a/AirTote.sln
+++ b/AirTote.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirTote.AISJapanParser", "A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirTote.AISJapanParser.Tests", "AirTote.AISJapanParser.Tests\AirTote.AISJapanParser.Tests.csproj", "{0231AB6F-4A44-48A8-B255-B129C1C303B8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AirTote.Services.JMA", "AirTote.Services.JMA\AirTote.Services.JMA.csproj", "{C7884BD9-EF9B-4C7D-8FA0-3C6122702EA0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -76,6 +78,12 @@ Global
 		{0231AB6F-4A44-48A8-B255-B129C1C303B8}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{0231AB6F-4A44-48A8-B255-B129C1C303B8}.Publish|Any CPU.ActiveCfg = Debug|Any CPU
 		{0231AB6F-4A44-48A8-B255-B129C1C303B8}.Publish|Any CPU.Build.0 = Debug|Any CPU
+		{C7884BD9-EF9B-4C7D-8FA0-3C6122702EA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7884BD9-EF9B-4C7D-8FA0-3C6122702EA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7884BD9-EF9B-4C7D-8FA0-3C6122702EA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7884BD9-EF9B-4C7D-8FA0-3C6122702EA0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7884BD9-EF9B-4C7D-8FA0-3C6122702EA0}.Publish|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7884BD9-EF9B-4C7D-8FA0-3C6122702EA0}.Publish|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AirTote/AirTote.csproj
+++ b/AirTote/AirTote.csproj
@@ -88,6 +88,7 @@
 		<ProjectReference Include="..\AirTote.SketchPad.MAUI\AirTote.SketchPad.MAUI.csproj" />
 		<ProjectReference Include="..\AirTote.Services\AirTote.Services.csproj" />
 	  <ProjectReference Include="..\AirTote.AISJapanParser\AirTote.AISJapanParser.csproj" />
+	  <ProjectReference Include="..\AirTote.Services.JMA\AirTote.Services.JMA.csproj" />
 	</ItemGroup>
 	<ItemGroup Condition="$(TargetFramework.StartsWith('net6.0-android')) != true">
 		<Compile Remove="**\**\*.Android.cs" />

--- a/AirTote/Assets/Raw/AdditionalLicenses/CC-BY-4.0
+++ b/AirTote/Assets/Raw/AdditionalLicenses/CC-BY-4.0
@@ -1,0 +1,156 @@
+Creative Commons Attribution 4.0 International
+
+ Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
+
+Considerations for licensors: Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. More considerations for licensors.
+
+Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+
+Section 1 – Definitions.
+
+     a.	Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+
+     b.	Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+
+     c.	Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+     d.	Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+
+     e.	Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+
+     f.	Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+
+     g.	Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+
+     h.	Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+
+     i.	Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+
+     j.	Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+
+     k.	You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+
+Section 2 – Scope.
+
+     a.	License grant.
+
+          1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+
+               A. reproduce and Share the Licensed Material, in whole or in part; and
+
+               B. produce, reproduce, and Share Adapted Material.
+
+          2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+
+          3. Term. The term of this Public License is specified in Section 6(a).
+
+          4. Media and formats; technical modifications allowed. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+
+          5. Downstream recipients.
+
+               A. Offer from the Licensor – Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+
+               B. No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+
+          6.  No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
+
+b. Other rights.
+
+          1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+
+          2. Patent and trademark rights are not licensed under this Public License.
+
+          3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
+
+Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+
+     a.	Attribution.
+
+          1. If You Share the Licensed Material (including in modified form), You must:
+
+               A. retain the following if it is supplied by the Licensor with the Licensed Material:
+
+                    i. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+
+                    ii. a copyright notice;
+
+                    iii. a notice that refers to this Public License;
+
+                    iv.	a notice that refers to the disclaimer of warranties;
+
+                    v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+
+               B. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+
+               C. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+
+          2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+
+          3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+          4. If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
+
+Section 4 – Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+
+     a.	for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
+
+     b.	if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
+
+     c.	You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+
+Section 5 – Disclaimer of Warranties and Limitation of Liability.
+
+     a.	Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.
+
+     b.	To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.
+
+     c.	The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
+Section 6 – Term and Termination.
+
+     a.	This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+
+     b.	Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+
+          1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+
+          2. upon express reinstatement by the Licensor.
+
+     c.	For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+
+     d.	For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+
+     e.	Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+Section 7 – Other Terms and Conditions.
+
+     a.	The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+
+     b.	Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+
+Section 8 – Interpretation.
+
+     a.	For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+
+     b.	To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+
+     c.	No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+
+     d.	Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+
+Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/AirTote/Assets/Raw/AdditionalLicenses/license_list.json
+++ b/AirTote/Assets/Raw/AdditionalLicenses/license_list.json
@@ -4,5 +4,11 @@
 		"license": "Apache-2.0",
 		"author": "Google",
 		"projectUrl": "https://github.com/google/material-design-icons"
+	},
+	{
+		"id": "気象庁公開のリソース",
+		"license": "CC-BY-4.0",
+		"author": "気象庁",
+		"projectUrl": "https://www.jma.go.jp/"
 	}
 ]

--- a/AirTote/Components/Maps/JMATileSelectingViewCell.xaml
+++ b/AirTote/Components/Maps/JMATileSelectingViewCell.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ViewCell
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Name="this"
+	x:Class="AirTote.Components.Maps.JMATileSelectingViewCell">
+	<RadioButton
+		VerticalOptions="Center"
+		CheckedChanged="RadioButton_CheckedChanged"
+		GroupName="JMATileSelectingViewCell"
+		IsChecked="{Binding Source={x:Reference this}, Path=IsChecked}"
+		Value="{Binding Source={x:Reference this}, Path=Value}"
+		Content="{Binding Source={x:Reference this}, Path=Text}"/>
+</ViewCell>

--- a/AirTote/Components/Maps/JMATileSelectingViewCell.xaml
+++ b/AirTote/Components/Maps/JMATileSelectingViewCell.xaml
@@ -9,6 +9,5 @@
 		CheckedChanged="RadioButton_CheckedChanged"
 		GroupName="JMATileSelectingViewCell"
 		IsChecked="{Binding Source={x:Reference this}, Path=IsChecked}"
-		Value="{Binding Source={x:Reference this}, Path=Value}"
 		Content="{Binding Source={x:Reference this}, Path=Text}"/>
 </ViewCell>

--- a/AirTote/Components/Maps/JMATileSelectingViewCell.xaml.cs
+++ b/AirTote/Components/Maps/JMATileSelectingViewCell.xaml.cs
@@ -170,8 +170,8 @@ public partial class JMATileSelectingViewCell : ViewCell
 
 		Top?.SetLayer(time, NowCTypes.Value);
 
-		if (DateTime.TryParse(time.validtime, out var value))
-			SetCurrentTimeText(value.ToLongDateString());
+		if (DateTime.TryParseExact(time.validtime, "yyyyMMddHHmmss", null, System.Globalization.DateTimeStyles.None, out var value))
+			SetCurrentTimeText($"{value:yyyy/MM/dd HH:mm} UTC");
 		else
 			SetCurrentTimeText(time.validtime);
 	}

--- a/AirTote/Components/Maps/JMATileSelectingViewCell.xaml.cs
+++ b/AirTote/Components/Maps/JMATileSelectingViewCell.xaml.cs
@@ -138,11 +138,13 @@ public partial class JMATileSelectingViewCell : ViewCell
 
 		if (index < 0)
 		{
-			index = timesList.Count - 1;
+			// 0寄りがLatest or Feature
+			// `time`指定が無い場合は、最新の情報を表示するようにする。
+			index = 0;
 			time = timesList[index];
 		}
 
-		CurrentTimeSlider.Value = index;
+		CurrentTimeSlider.Value = timesList.Count - index - 1;
 
 		SetLayer(time!);
 	}
@@ -161,7 +163,7 @@ public partial class JMATileSelectingViewCell : ViewCell
 			return;
 
 		if ((int)e.OldValue != (int)e.NewValue)
-			SetLayer(TargetTimeList[(int)e.NewValue]);
+			SetLayer(TargetTimeList[TargetTimeList.Count - (int)e.NewValue - 1]);
 	}
 	private void SetLayer(TargetTimes time)
 	{

--- a/AirTote/Components/Maps/JMATileSelectingViewCell.xaml.cs
+++ b/AirTote/Components/Maps/JMATileSelectingViewCell.xaml.cs
@@ -1,0 +1,97 @@
+using AirTote.Pages.TabChild;
+using AirTote.Services.JMA;
+using AirTote.Services.JMA.Models;
+
+using DependencyPropertyGenerator;
+
+namespace AirTote.Components.Maps;
+
+[DependencyProperty<TopPage>("Top")]
+[DependencyProperty<string>("Value")]
+[DependencyProperty<string>("Text")]
+[DependencyProperty<bool>("IsChecked", DefaultBindingMode = DefaultBindingMode.TwoWay)]
+public partial class JMATileSelectingViewCell : ViewCell
+{
+	public JMATileSelectingViewCell()
+	{
+		InitializeComponent();
+	}
+
+	public JMATileSelectingViewCell(TopPage top) : this()
+	{
+		Top = top;
+	}
+
+	partial void OnTopChanged()
+		=> UpdateIsChecked();
+	partial void OnValueChanged()
+		=> UpdateIsChecked();
+
+	void UpdateIsChecked()
+	{
+		if (Top is null || string.IsNullOrEmpty(Value))
+		{
+			IsEnabled = false;
+			return;
+		}
+
+		IsEnabled = true;
+
+		if (Top.JMATileLayer is null)
+		{
+			IsChecked = (Value == "none");
+			return;
+		}
+
+		IsChecked = Value switch
+		{
+			TargetTimes.TYPE_HIGH_RESOLUTION_PRECIPITATION_NOWCASTS => Top.CurrentNowC_Type == NowC_Types.HRPNs,
+			TargetTimes.TYPE_THUNDER_NOWCASTS => Top.CurrentNowC_Type == NowC_Types.THNs,
+			TargetTimes.TYPE_TORNADO_NOWCASTS => Top.CurrentNowC_Type == NowC_Types.TRNs,
+			_ => false
+		};
+	}
+
+	async void RadioButton_CheckedChanged(object sender, CheckedChangedEventArgs e)
+	{
+		if (sender is not RadioButton radioButton || Top is null || !e.Value)
+			return;
+
+		if (Top.JMATiles is null)
+			await ReloadJMATiles();
+		if (Top.JMATiles is null)
+			return;
+
+		switch (radioButton.Value)
+		{
+			case TargetTimes.TYPE_HIGH_RESOLUTION_PRECIPITATION_NOWCASTS:
+				if (Top.JMATiles.HRPNs_Latest is not null)
+					Top.SetLayer(Top.JMATiles.HRPNs_Latest, NowC_Types.HRPNs);
+				break;
+
+			case TargetTimes.TYPE_THUNDER_NOWCASTS:
+				if (Top.JMATiles.THNsTimeList.FirstOrDefault() is TargetTimes thns)
+					Top.SetLayer(thns, NowC_Types.THNs);
+				break;
+
+			case TargetTimes.TYPE_TORNADO_NOWCASTS:
+				if (Top.JMATiles.TRNsTimeList.FirstOrDefault() is TargetTimes trns)
+					Top.SetLayer(trns, NowC_Types.TRNs);
+				break;
+
+			default:
+				Top.JMATileLayer = null;
+				break;
+		}
+	}
+
+	async Task ReloadJMATiles()
+	{
+		if (Top is null)
+			return;
+
+		Top.JMATiles = await JMATilesProvider.Init();
+		System.Diagnostics.Debug.WriteLine($"{nameof(JMATileSelectingViewCell)}.{nameof(ReloadJMATiles)}() ... Latest HRPNs = {Top.JMATiles.HRPNs_Latest}");
+	}
+}
+

--- a/AirTote/Components/Maps/MapSettingPopup.xaml
+++ b/AirTote/Components/Maps/MapSettingPopup.xaml
@@ -4,7 +4,7 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
 	xmlns:local="clr-namespace:AirTote.Components.Maps"
-	xmlns:jmaModel="clr-namespace:AirTote.Services.JMA.Models;assembly=AirTote.Services.JMA"
+	xmlns:services="clr-namespace:AirTote.Services"
 	Color="{AppThemeBinding Light={StaticResource LightBackgroundColor}, Dark={StaticResource DarkBackgroundColor}}"
 	x:Name="this"
 	x:Class="AirTote.Components.Maps.MapSettingPopup">
@@ -34,6 +34,24 @@
 					x:Name="MapTypeSection" />
 				<TableSection
 					Title="気象庁ナウキャスト">
+					<ViewCell>
+						<VerticalStackLayout>
+							<Label
+								Text="気象庁のWebサイトで確認する"
+								TextColor="{AppThemeBinding Default=#07E, Dark=#49F}"
+								Margin="2"/>
+							<Label
+								FontSize="10"
+								Text="本機能は、上記ページをCC-BY-4.0に基づいて利用しています。"
+								TextColor="#888"/>
+							<VerticalStackLayout.GestureRecognizers>
+								<TapGestureRecognizer
+									Command="{x:Static services:OpenBrowserCommand.Default}"
+									CommandParameter="https://www.jma.go.jp/bosai/nowc/"/>
+							</VerticalStackLayout.GestureRecognizers>
+						</VerticalStackLayout>
+					</ViewCell>
+
 					<local:JMATileSelectingViewCell
 						CurrentTimeTextCell="{x:Reference JMATileTimeTextCell}"
 						CurrentTimeSlider="{x:Reference JMATileTimeSlider}"

--- a/AirTote/Components/Maps/MapSettingPopup.xaml
+++ b/AirTote/Components/Maps/MapSettingPopup.xaml
@@ -35,21 +35,36 @@
 				<TableSection
 					Title="気象庁ナウキャスト">
 					<local:JMATileSelectingViewCell
+						CurrentTimeTextCell="{x:Reference JMATileTimeTextCell}"
+						CurrentTimeSlider="{x:Reference JMATileTimeSlider}"
 						Top="{Binding Source={x:Reference this}, Path=Top}"
-						Value="none"
+						NowCTypes="{x:Null}"
 						Text="なし"/>
 					<local:JMATileSelectingViewCell
+						CurrentTimeTextCell="{x:Reference JMATileTimeTextCell}"
+						CurrentTimeSlider="{x:Reference JMATileTimeSlider}"
 						Top="{Binding Source={x:Reference this}, Path=Top}"
-						Value="{x:Static jmaModel:TargetTimes.TYPE_HIGH_RESOLUTION_PRECIPITATION_NOWCASTS}"
+						NowCTypes="HRPNs"
 						Text="雨雲の動き"/>
 					<local:JMATileSelectingViewCell
+						CurrentTimeTextCell="{x:Reference JMATileTimeTextCell}"
+						CurrentTimeSlider="{x:Reference JMATileTimeSlider}"
 						Top="{Binding Source={x:Reference this}, Path=Top}"
-						Value="{x:Static jmaModel:TargetTimes.TYPE_THUNDER_NOWCASTS}"
+						NowCTypes="THNs"
 						Text="雷活動度"/>
 					<local:JMATileSelectingViewCell
+						CurrentTimeTextCell="{x:Reference JMATileTimeTextCell}"
+						CurrentTimeSlider="{x:Reference JMATileTimeSlider}"
 						Top="{Binding Source={x:Reference this}, Path=Top}"
-						Value="{x:Static jmaModel:TargetTimes.TYPE_TORNADO_NOWCASTS}"
+						NowCTypes="TRNs"
 						Text="竜巻発生確度"/>
+
+					<TextCell
+						x:Name="JMATileTimeTextCell"/>
+					<ViewCell>
+						<Slider
+							x:Name="JMATileTimeSlider"/>
+					</ViewCell>
 				</TableSection>
 				<TableSection
 					Title="Layers"

--- a/AirTote/Components/Maps/MapSettingPopup.xaml
+++ b/AirTote/Components/Maps/MapSettingPopup.xaml
@@ -3,7 +3,10 @@
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+	xmlns:local="clr-namespace:AirTote.Components.Maps"
+	xmlns:jmaModel="clr-namespace:AirTote.Services.JMA.Models;assembly=AirTote.Services.JMA"
 	Color="{AppThemeBinding Light={StaticResource LightBackgroundColor}, Dark={StaticResource DarkBackgroundColor}}"
+	x:Name="this"
 	x:Class="AirTote.Components.Maps.MapSettingPopup">
 	<Grid>
 		<Grid.RowDefinitions>
@@ -29,6 +32,25 @@
 				<TableSection
 					Title="Map Types"
 					x:Name="MapTypeSection" />
+				<TableSection
+					Title="気象庁ナウキャスト">
+					<local:JMATileSelectingViewCell
+						Top="{Binding Source={x:Reference this}, Path=Top}"
+						Value="none"
+						Text="なし"/>
+					<local:JMATileSelectingViewCell
+						Top="{Binding Source={x:Reference this}, Path=Top}"
+						Value="{x:Static jmaModel:TargetTimes.TYPE_HIGH_RESOLUTION_PRECIPITATION_NOWCASTS}"
+						Text="雨雲の動き"/>
+					<local:JMATileSelectingViewCell
+						Top="{Binding Source={x:Reference this}, Path=Top}"
+						Value="{x:Static jmaModel:TargetTimes.TYPE_THUNDER_NOWCASTS}"
+						Text="雷活動度"/>
+					<local:JMATileSelectingViewCell
+						Top="{Binding Source={x:Reference this}, Path=Top}"
+						Value="{x:Static jmaModel:TargetTimes.TYPE_TORNADO_NOWCASTS}"
+						Text="竜巻発生確度"/>
+				</TableSection>
 				<TableSection
 					Title="Layers"
 					x:Name="LayersSection" />

--- a/AirTote/Components/Maps/MapSettingPopup.xaml.cs
+++ b/AirTote/Components/Maps/MapSettingPopup.xaml.cs
@@ -1,19 +1,23 @@
 using AirTote.Components.Maps.Widgets;
+using AirTote.Pages.TabChild;
 
 using CommunityToolkit.Maui.Views;
+
+using DependencyPropertyGenerator;
 
 using Mapsui;
 
 namespace AirTote.Components.Maps;
 
+[DependencyProperty<TopPage>("Top")]
 public partial class MapSettingPopup : Popup
 {
 	AirMap Map { get; }
 
-	public MapSettingPopup(AirMap map, Action RefleshCanvas)
+	public MapSettingPopup(TopPage top, Action RefleshCanvas)
 	{
-		Map = map;
-		if (map.Map is null)
+		Map = top.Map;
+		if (Map.Map is null)
 			throw new ArgumentNullException(nameof(Map.Map));
 
 		// code from: https://github.com/CommunityToolkit/Maui/blob/68b82412a7e31d961b7ec0da2909f38e2a07ff9a/samples/CommunityToolkit.Maui.Sample/Models/PopupSize.cs#L10
@@ -26,21 +30,28 @@ public partial class MapSettingPopup : Popup
 
 		InitializeComponent();
 
+		InitSections(Map, Map.Map, RefleshCanvas);
+
+		this.Top = top;
+	}
+
+	void InitSections(AirMap airMap, Mapsui.Map map, Action RefleshCanvas)
+	{
 		List<MapTileSettingViewCell> MapTypeCells = new();
 		foreach (var v in TileProvider.TileSources.Values)
 		{
-			MapTileSettingViewCell cell = new(MapTypeCells, map.CurrentMapTileLayer?.Name == v.Name, Map, v);
+			MapTileSettingViewCell cell = new(MapTypeCells, airMap.CurrentMapTileLayer?.Name == v.Name, Map, v);
 			MapTypeCells.Add(cell);
 			MapTypeSection.Add(cell);
 		}
 
-		foreach (var layer in map.Map.Layers)
+		foreach (var layer in map.Layers)
 		{
 			if (layer.IsMapInfoLayer)
 				LayersSection.Add(new MapSettingViewCell(layer));
 		}
 
-		foreach (var widget in map.Map.Widgets)
+		foreach (var widget in map.Widgets)
 		{
 			if (widget is not INamedWidget namedWidget)
 				continue;

--- a/AirTote/Components/Maps/TileProvider.cs
+++ b/AirTote/Components/Maps/TileProvider.cs
@@ -53,21 +53,6 @@ public static class TileProvider
 		return CreateLayer(value);
 	}
 
-	static async Task<byte[]> GetByteArrayAsync(Uri uri)
-	{
-		try
-		{
-			using HttpResponseMessage res = await HttpService.HttpClient.GetAsync(uri);
-
-			return res.IsSuccessStatusCode ? await res.Content.ReadAsByteArrayAsync() : Array.Empty<byte>();
-		}
-		catch (TaskCanceledException)
-		{
-			// When Timeout
-			return Array.Empty<byte>();
-		}
-	}
-
 	public static TileLayer CreateLayer(MapTileSourceInfo value)
 		=> CreateLayer(value, null);
 	public static TileLayer CreateJMALayer(MapTileSourceInfo value)
@@ -80,7 +65,7 @@ public static class TileProvider
 				value.UrlFormatter,
 				name: value.Name,
 				persistentCache: DefaultCache,
-				tileFetcher: GetByteArrayAsync,
+				tileFetcher: HttpService.GetByteArrayAsync,
 				userAgent: USER_AGENT,
 				attribution: AttributionInfo
 			))

--- a/AirTote/Components/Maps/TileProvider.cs
+++ b/AirTote/Components/Maps/TileProvider.cs
@@ -52,19 +52,14 @@ public static class TileProvider
 	}
 
 	public static TileLayer CreateLayer(MapTileSourceInfo value)
-		=> CreateLayer(value, null);
-	public static TileLayer CreateJMALayer(MapTileSourceInfo value)
-		=> CreateLayer(value, new GlobalSphericalMercator(4, 10));
-
-	public static TileLayer CreateLayer(MapTileSourceInfo value, ITileSchema? tileSchema)
 	{
 		TileLayer layer = new(new HttpTileSource(
-				tileSchema ?? new GlobalSphericalMercator(4, 10),
+				new GlobalSphericalMercator(),
 				value.UrlFormatter,
 				name: value.Name,
 				persistentCache: DefaultCache,
 				tileFetcher: HttpService.GetByteArrayAsync,
-				userAgent: USER_AGENT,
+				userAgent: HttpService.USER_AGENT,
 				attribution: AttributionInfo
 			))
 		{
@@ -72,20 +67,6 @@ public static class TileProvider
 		};
 
 		layer.Attribution.Enabled = false;
-
-		return layer;
-	}
-
-	public static TileLayer Create_JMA_NOWC_Layer(DateTime UTCDateTime)
-	{
-		DateTime dateTime = new(UTCDateTime.Year, UTCDateTime.Month, UTCDateTime.Day, UTCDateTime.Hour, UTCDateTime.Minute - (UTCDateTime.Minute % 5), 0, DateTimeKind.Utc);
-
-		TileLayer layer = CreateJMALayer(new MapTileSourceInfo(
-				@$"https://www.jma.go.jp/bosai/jmatile/data/nowc/{dateTime:yyyyMMddhhmmss}/none/{dateTime:yyyyMMddhhmmss}/surf/hrpns/" + "{z}/{x}/{y}.png",
-				"雨雲の動き (高解像度降水ナウキャスト)",
-				new("出典: 気象庁 ナウキャスト", "https://www.jma.go.jp/bosai/nowc/")
-			));
-		layer.IsMapInfoLayer = true;
 
 		return layer;
 	}

--- a/AirTote/Components/Maps/TileProvider.cs
+++ b/AirTote/Components/Maps/TileProvider.cs
@@ -21,8 +21,6 @@ public static class TileProvider
 
 	public static Attribution AttributionInfo { get; } = new("出典: 地理院タイル\n" + MAP_ADDITIONAL_ATTR, "https://maps.gsi.go.jp/development/ichiran.html");
 
-	static string USER_AGENT => HttpService.HttpClient.DefaultRequestHeaders.UserAgent.ToString();
-
 	static Dictionary<string, MapTileSourceInfo> _TileSources { get; } = new();
 	public static IReadOnlyDictionary<string, MapTileSourceInfo> TileSources => _TileSources;
 	public const string DEFAULT_MAP_SOURCE_KEY = "gsi_jp_pale";

--- a/AirTote/Pages/TabChild/TopPage.xaml
+++ b/AirTote/Pages/TabChild/TopPage.xaml
@@ -6,5 +6,6 @@
 	x:Class="AirTote.Pages.TabChild.TopPage"
 	Title="Flight Information">
 	<maps:AirportMap
+		x:FieldModifier="public"
 		x:Name="Map"/>
 </ContentPage>

--- a/AirTote/Pages/TabChild/TopPage.xaml.cs
+++ b/AirTote/Pages/TabChild/TopPage.xaml.cs
@@ -250,7 +250,7 @@ public partial class TopPage : ContentPage, IContainFlyoutPageInstance
 		if (Map.Map is null)
 			return;
 
-		this.ShowPopup(new MapSettingPopup(this.Map, Map.RefreshGraphics));
+		this.ShowPopup(new MapSettingPopup(this, Map.RefreshGraphics));
 	}
 
 	void UpdateMyLocation(Location loc)

--- a/AirTote/Pages/TabChild/TopPage.xaml.cs
+++ b/AirTote/Pages/TabChild/TopPage.xaml.cs
@@ -36,6 +36,7 @@ public partial class TopPage : ContentPage, IContainFlyoutPageInstance
 
 	public JMATilesProvider? JMATiles { get; set; }
 	public NowC_Types CurrentNowC_Type { get; private set; }
+	public TargetTimes CurrentTargetTimes { get; private set; }
 	TileLayer? _JMATileLayer = null;
 	public TileLayer? JMATileLayer
 	{
@@ -254,8 +255,12 @@ public partial class TopPage : ContentPage, IContainFlyoutPageInstance
 
 	public void SetLayer(TargetTimes time, NowC_Types type)
 	{
-		JMATileLayer = JMATilesProvider.GetLayer(time, type);
-		CurrentNowC_Type = type;
+		if (time != CurrentTargetTimes || type != CurrentNowC_Type)
+		{
+			JMATileLayer = JMATilesProvider.GetLayer(time, type);
+			CurrentTargetTimes = time;
+			CurrentNowC_Type = type;
+		}
 
 		System.Diagnostics.Debug.WriteLine($"{nameof(TopPage)}.{nameof(SetLayer)}({time}, {type})");
 	}

--- a/AirTote/Services/OpenBrowserCommand.cs
+++ b/AirTote/Services/OpenBrowserCommand.cs
@@ -4,6 +4,8 @@ namespace AirTote.Services;
 
 internal class OpenBrowserCommand : ICommand
 {
+	public static readonly OpenBrowserCommand Default = new();
+
 	public event EventHandler? CanExecuteChanged;
 
 	public bool CanExecute(object? parameter)


### PR DESCRIPTION
resolve #124 

気象庁のナウキャストについて、サーバから時刻情報を取得することで最新の情報を表示できるようにした。
但し、最新情報のチェックはページ表示毎であり、ページ内にリロードボタンは用意していない。

ついでに、表示するデータについても、時間を選択できるようにした。

![simulator_screenshot_68D3BB17-C0EA-49AE-B9E0-7F9EDE2C8DBA](https://user-images.githubusercontent.com/31824852/195985847-dc0a9191-9cdd-4bdc-b56b-b2734819962e.png)
