### PR TITLE
iPhone / iPodでSketch Padを表示しないようにした

### DIFF
--- a/AirTote/TabMainPage.xaml.cs
+++ b/AirTote/TabMainPage.xaml.cs
@@ -23,7 +23,7 @@ public partial class TabMainPage : Shell
 		InitializeComponent();
 
 #if IOS
-		if (new Version(13, 0) <= DeviceInfo.Version)
+		if (new Version(13, 0) <= DeviceInfo.Version && DeviceInfo.Current.Idiom != DeviceIdiom.Phone)
 			SketchPadTab.IsVisible = true;
 #endif
 	}


### PR DESCRIPTION
<img width="427" alt="Screenshot 2023-03-27 at 14 08 04" src="https://user-images.githubusercontent.com/31824852/227846066-62d7cf6f-75fe-4df0-9f80-a6b2f4db3bfc.png">
